### PR TITLE
OnEngineReload: add unregisterOnReloadEngine global JS function

### DIFF
--- a/Runtime/Engine/JSGlobals/OnEngineReload.cs
+++ b/Runtime/Engine/JSGlobals/OnEngineReload.cs
@@ -7,8 +7,10 @@ namespace OneJS.Engine.JSGlobals {
     public class OnEngineReload {
         public static void Setup(ScriptEngine engine) {
             engine.JintEngine.SetValue("onEngineReload", new Action<JsValue>((handler) => {
-                Action action = () => { handler.As<Jint.Native.Function.FunctionInstance>().Call(); };
-                engine.RegisterReloadHandler(action);
+                engine.RegisterReloadHandler(handler.As<Jint.Native.Function.FunctionInstance>());
+            }));
+            engine.JintEngine.SetValue("unregisterOnEngineReload", new Action<JsValue>((handler) => {
+                engine.UnregisterReloadHandler(handler.As<Jint.Native.Function.FunctionInstance>());
             }));
         }
     }


### PR DESCRIPTION
This PR adds the ability to _unregister_ reload callbacks from `ScriptEngine`, and exposes this to JS scripts via the global function `unregisterOnEngineReload`.

### Why do we need this?

`onReloadEngine` is meant to be called at various points in JavaScript, in particular during React component initialization. However, because there is currently no way to unregister callbacks added via `onReloadEngine`, these callbacks will necessarily outlive the components and/or contexts they were created from. They will _only_ be cleaned up if the script engine reloads, which is not a guarantee, especially in production.

Callbacks may contain strong references to arbitrary C# data, so this constitutes a memory leak. This change allows JS scripts to clean up their reload callbacks when they become unnecessary.

### Implementation details

In order to unregister callbacks, the reload callback list must store values that can be removed via `List.Remove()`. The current list (`ScriptEngine._engineReloadJSHandlers`) stores _wrapped_ versions of the `JsValue` functions, making it impossible to perform equality comparisons against JS callback values that are passed via `unregisterOnReloadEngine`.

As a workaround, this PR no longer performs callback wrapping when executing `onEngineReload`. Instead, the `JsValue` function values are stored directly.

One consequence of this change is that the `OnReload` event (used by `JanitorSpawner`) is no longer executed in the same sequence as `onReloadEngine` callbacks. I think this should be totally fine, but it's worth considering if this will cause any side-effects.

### After this PR lands

There should be a corresponding update to `ScriptLib` that creates a type definition for `unregisterOnReloadEngine`.