### PR TITLE
Add ability to run modules via source code

### DIFF
--- a/Runtime/ScriptEngine.cs
+++ b/Runtime/ScriptEngine.cs
@@ -248,10 +248,8 @@ namespace OneJS {
                 Debug.LogError($"File ({path}) doesn't exist.");
                 return;
             }
-            RunJsReloadHandlers();
-            OnReload?.Invoke();
-            CleanUp();
-            InitEngine();
+
+            Reload();
             RunModule(scriptPath);
         }
 
@@ -317,7 +315,7 @@ namespace OneJS {
         }
 
         /// <summary>
-        /// Apply all class string processors. 
+        /// Apply all class string processors.
         /// </summary>
         /// <param name="classString">String of class names</param>
         /// <param name="dom">The Dom that is setting the class attribute right now</param>
@@ -485,6 +483,13 @@ namespace OneJS {
             // Debug.Log($"{a} {b} {c}");
             // print($"RunModule {(DateTime.Now - t).TotalMilliseconds}ms");
             _postloadedScripts.ForEach(p => _cjsEngine.RunMain(p));
+        }
+
+        public void Reload() {
+            RunJsReloadHandlers();
+            OnReload?.Invoke();
+            CleanUp();
+            InitEngine();
         }
     }
 


### PR DESCRIPTION
This PR introduces some public-methods in `ScriptEngine` and `ModuleLoadingEngine` that make it possible to run JS from string buffers, rather than from disk.

- `ModuleLoadingEngine.RunSource` executes source code provided as a C# string.
- `ScriptEngine.Reload` resets the engine state. Previously, this functionality was not exposed publicly, and would only occur when re-loading scripts from the filesystem.