### PR TITLE
Improve DOM event lookup

### DIFF
--- a/Runtime/Dom/Dom.cs
+++ b/Runtime/Dom/Dom.cs
@@ -140,7 +140,7 @@ namespace OneJS.Dom {
                 _eventCache[name](_ve, callback, TrickleDown.NoTrickleDown);
                 // Debug.Log("Registered " + name + " on " + _ve.name);
             } else {
-                var eventType = _document.FindUIElementEventType(name);
+                Type eventType = null;
                 if (isValueChanged) {
                     var notifyInterface = _ve.GetType().GetInterfaces().Where(i => i.Name == "INotifyValueChanged`1")
                         .FirstOrDefault();
@@ -149,7 +149,10 @@ namespace OneJS.Dom {
                         eventType = typeof(VisualElement).Assembly.GetType($"UnityEngine.UIElements.ChangeEvent`1");
                         eventType = eventType.MakeGenericType(valType);
                     }
+                } else {
+                    eventType = _document.FindUIElementEventType(name);
                 }
+
                 if (eventType != null) {
                     var mi = this.GetType().GetMethod("RegisterCallback");
                     mi = mi.MakeGenericMethod(eventType);


### PR DESCRIPTION
Improve DOM event lookup by adding both full event name and event name without `Event` suffix to the event lookup dictionary. This avoids the need to lookup an event twice during `addEventListener()` if event name doesn't have `Event` suffix.