### PR TITLE
Fix path resolving for MPPM

### DIFF
--- a/Runtime/Engine/ScriptEngine.cs
+++ b/Runtime/Engine/ScriptEngine.cs
@@ -86,12 +86,11 @@ namespace OneJS {
                     Directory.CreateDirectory(path);
                 }
 #if MULTIPLAYER_PLAYMODE_ENABLED
-                if ( path.Contains( $"Library{Path.DirectorySeparatorChar}VP" ) )
-                {
+                if (path.Contains($"Library{Path.DirectorySeparatorChar}VP")) {
                     // MPPM is active
-                    path = Path.Combine( Path.GetDirectoryName( Application.dataPath )!,
+                    path = Path.Combine(Path.GetDirectoryName(Application.dataPath)!,
                         "..", "..", "..",
-                        editorWorkingDirInfo.relativePath );
+                        editorWorkingDirInfo.relativePath);
                 }
 #endif
                 return path;


### PR DESCRIPTION
- I checked out the preprocessors in MPPM and the only options are `MULTIPLAY_API_AVAILABLE` and `UNITY_MP_TOOLS_DEV`, not related to MPPM at all.
- The white space is getting formatted because of `trim_trailing_whitespace = true` in the `.editorconfig`

Let me know of any changes or if you want me to document this anywhere as well.