### PR TITLE
static-ize regex in DomStyle

### DIFF
--- a/Runtime/Dom/DomStyle.cs
+++ b/Runtime/Dom/DomStyle.cs
@@ -1558,7 +1558,7 @@ namespace OneJS.Dom {
             }
         }
 
-        Regex rotateRegex = new Regex(@"(-?\d+\.?\d*|\.\d+)(deg|grad|rad|turn)", RegexOptions.IgnoreCase);
+        static Regex rotateRegex = new Regex(@"(-?\d+\.?\d*|\.\d+)(deg|grad|rad|turn)", RegexOptions.IgnoreCase);
 
         bool TryParseStyleRotate(object value, out StyleRotate styleRotate) {
             if (value is string ss && StyleKeyword.TryParse(ss, true, out StyleKeyword keyword)) {
@@ -1751,7 +1751,7 @@ namespace OneJS.Dom {
             return false;
         }
 
-        Regex timeRegex = new Regex(@"(-?\d+\.?\d*)(s|ms)", RegexOptions.IgnoreCase);
+        static Regex timeRegex = new Regex(@"(-?\d+\.?\d*)(s|ms)", RegexOptions.IgnoreCase);
 
         bool TryParseStyleListTimeValue(object value, out StyleList<TimeValue> styleListTimeValue) {
             if (value is string ss && StyleKeyword.TryParse(ss, true, out StyleKeyword keyword)) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dd21fefe-a33b-4ae3-a842-c7039d7e307e)
aimed to reduce instantiating regex used in DomStyle
this is the most obvious hotspot for regex used, can probably make a repo-wide regex cache but that's too involved rn