### PR TITLE
Replace _instanceId hash with clean counter-based folder naming

### DIFF
--- a/Editor/JSRunnerBuildProcessor.cs
+++ b/Editor/JSRunnerBuildProcessor.cs
@@ -14,8 +14,8 @@ using UnityEngine.SceneManagement;
 /// Scans all enabled scenes in Build Settings and generates TextAssets for each JSRunner.
 ///
 /// Directory structure:
-///   {SceneDir}/{SceneName}/{GameObjectName}_{InstanceId}/app.js.txt
-///   {SceneDir}/{SceneName}/{GameObjectName}_{InstanceId}/app.js.txt.map (optional)
+///   {SceneDir}/{SceneName}/{GameObjectName}/app.js.txt
+///   {SceneDir}/{SceneName}/{GameObjectName}/app.js.txt.map (optional)
 /// </summary>
 public class JSRunnerBuildProcessor : IPreprocessBuildWithReport, IPostprocessBuildWithReport {
     public int callbackOrder => 0;

--- a/Runtime/README.md
+++ b/Runtime/README.md
@@ -63,7 +63,7 @@ JSRunner uses the **assigned PanelSettings asset** as the source of truth for pr
 ```
 Assets/Scenes/Level1.unity          # Your scene
 Assets/Scenes/Level1/               # Auto-created folder next to scene
-├── MainUI_abc123/                  # Instance folder (name + instanceId)
+├── MainUI/                         # Instance folder (counter-based: MainUI, MainUI_1, ...)
 │   ├── ~/                          # Working directory (~ makes Unity ignore it)
 │   │   ├── package.json            # Scaffolded on Initialize
 │   │   ├── index.tsx               # Source file
@@ -76,7 +76,7 @@ Assets/Scenes/Level1/               # Auto-created folder next to scene
 
 **Key points:**
 - **PanelSettings location = project folder**. Moving the PanelSettings asset moves the project.
-- Each JSRunner gets its own isolated workspace via instance ID suffix
+- Each JSRunner gets its own isolated workspace (counter suffix added if name conflicts)
 - `~` suffix on the working directory makes Unity ignore it (no .meta files)
 - UIDocument component is added at runtime (not `[RequireComponent]`)
 - VisualTreeAsset is auto-synced from the PanelSettings folder


### PR DESCRIPTION
## Summary

- Remove `_instanceId` SerializeField and `InstanceId` property from JSRunner
- Replace random GUID folder names (e.g. `App_a8f76343`) with human-readable counter-based names: `App`, `App_1`, `App_2`
- Add `FindAvailableFolderPath()` static helper with counter-based naming (up to 1000, GUID fallback)
- Update doc comments in JSRunner, JSRunnerBuildProcessor, and Runtime README

Since PanelSettings is now the project identity (#85), the hash suffix was purely cosmetic. Existing projects are unaffected — `EnsureProjectFolderAndAssets` early-returns when PanelSettings is already assigned.

Closes #86

## Test plan

- [x] Unity compilation: clean, no errors
- [x] Open Unity, create new scene, add JSRunner, click Initialize → folder should be `{GOName}/` (no suffix)
- [x] Add second JSRunner with same GO name, Initialize → folder should be `{GOName}_1/`
- [x] Existing `App_a8f76343` project in MainScene still works (PanelSettings already assigned)