### PR TITLE
Fix struct serialization destroying UnityEngine.Object references

### DIFF
--- a/Runtime/QuickJSNative.Structs.cs
+++ b/Runtime/QuickJSNative.Structs.cs
@@ -122,7 +122,22 @@ public static partial class QuickJSNative {
         var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         if (fields.Length == 0 && props.Length == 0) return false;
 
+        // Skip structs containing UnityEngine.Object references (e.g., FontDefinition).
+        // These references cannot survive JSON round-tripping (ToString() destroys them).
+        // They must fall through to the ObjectHandle path to preserve C# references.
+        if (HasUnityObjectMembers(fields, props)) return false;
+
         return true;
+    }
+
+    static bool HasUnityObjectMembers(FieldInfo[] fields, PropertyInfo[] props) {
+        for (int i = 0; i < fields.Length; i++) {
+            if (typeof(UnityEngine.Object).IsAssignableFrom(fields[i].FieldType)) return true;
+        }
+        for (int i = 0; i < props.Length; i++) {
+            if (typeof(UnityEngine.Object).IsAssignableFrom(props[i].PropertyType)) return true;
+        }
+        return false;
     }
 
     // MARK: Init

--- a/Runtime/Styling/UssCompiler.cs
+++ b/Runtime/Styling/UssCompiler.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using ExCSS;
 using UnityEngine;
+using UnityEngine.TextCore.Text;
 using UnityEngine.UIElements;
 
 namespace OneJS.CustomStyleSheets {
@@ -533,8 +534,9 @@ namespace OneJS.CustomStyleSheets {
 
                 case ".ttf":
                 case ".otf":
-                    var font = new Font(fullPath);
-                    _builder.AddValue(font);
+                    var legacyFont = new Font(fullPath);
+                    var fontAsset = FontAsset.CreateFontAsset(legacyFont);
+                    _builder.AddValue(fontAsset);
                     break;
             }
         }


### PR DESCRIPTION
## Problem

Structs containing `UnityEngine.Object` fields/properties (e.g., `FontDefinition`) were being auto-registered for JSON serialization. During serialization, reference-type fields fell back to `ToString()`, permanently destroying the live C# object reference.

When the serialized struct was later assigned back to a C# property (e.g., `element.style.unityFontDefinition`), deserialization could not reconstruct the original object, resulting in silently lost data (e.g., fonts not rendering).

## Fix

Added a check in ShouldAutoRegister to skip structs that contain `UnityEngine.Object` members. These structs now fall through to the **ObjectHandle** path, preserving live C# references across the JS↔C# boundary.

The existing TryConstructorConversion handles wrapping automatically (e.g., `FontDefinition` → `StyleFontDefinition`).

## Affected Types

- `FontDefinition` (contains `Font` and `FontAsset` properties)
- Any other struct holding `UnityEngine.Object` references