### PR TITLE
Fix ResetPlayModeState not available in player builds

### DIFF
--- a/Runtime/JSRunner.cs
+++ b/Runtime/JSRunner.cs
@@ -1217,6 +1217,14 @@ public class JSRunner : MonoBehaviour {
         return true;
     }
 
+    void ResetPlayModeState() {
+        _initialized = false;
+        _scriptLoaded = false;
+        _onPlayHandle = -1;
+        _onStopHandle = -1;
+        _onStopInvoked = false;
+    }
+
 #if UNITY_EDITOR
     void Reload() {
         if (!File.Exists(EntryFileFullPath)) {
@@ -1345,14 +1353,6 @@ public class JSRunner : MonoBehaviour {
                 ResetPlayModeState();
                 break;
         }
-    }
-
-    void ResetPlayModeState() {
-        _initialized = false;
-        _scriptLoaded = false;
-        _onPlayHandle = -1;
-        _onStopHandle = -1;
-        _onStopInvoked = false;
     }
 
     void TryStartEditModePreview() {


### PR DESCRIPTION
`ResetPlayModeState()` was defined inside `#if UNITY_EDITOR` but called from `ReloadOnEnable()` which runs in builds too, causing CS0103 errors on build. The method only resets plain fields with no editor dependencies, so move it outside the preprocessor block.

This should fix builds.