### PR TITLE
Make TypeGenerator resilient to exotic reflection metadata

### DIFF
--- a/Editor/TypeGenerator/Analysis/TypeAnalyzer.cs
+++ b/Editor/TypeGenerator/Analysis/TypeAnalyzer.cs
@@ -86,12 +86,31 @@ namespace OneJS.Editor.TypeGenerator {
         public List<TsTypeInfo> AnalyzeTypes(IEnumerable<Type> types) {
             var results = new List<TsTypeInfo>();
             foreach (var type in types) {
-                var info = AnalyzeType(type);
-                if (info != null) {
-                    results.Add(info);
+                // Per-type isolation: a single reflection failure (e.g.
+                // "Array type can not be an open generic type" thrown when
+                // enumerating members of some Unity.Localization types) must
+                // not abort the entire generation pass. Log and move on so
+                // the remaining types still get their typings emitted.
+                try {
+                    var info = AnalyzeType(type);
+                    if (info != null) {
+                        results.Add(info);
+                    }
+                } catch (Exception ex) {
+                    UnityEngine.Debug.LogWarning(
+                        $"[TypeAnalyzer] Skipping '{SafeTypeName(type)}': {ex.Message}");
                 }
             }
             return results;
+        }
+
+        private static string SafeTypeName(Type type) {
+            if (type == null) return "<null>";
+            try {
+                return type.FullName ?? type.Name;
+            } catch {
+                try { return type.Name; } catch { return "<unknown>"; }
+            }
         }
 
         /// <summary>

--- a/Editor/TypeGenerator/Analysis/TypeAnalyzer.cs
+++ b/Editor/TypeGenerator/Analysis/TypeAnalyzer.cs
@@ -98,19 +98,10 @@ namespace OneJS.Editor.TypeGenerator {
                     }
                 } catch (Exception ex) {
                     UnityEngine.Debug.LogWarning(
-                        $"[TypeAnalyzer] Skipping '{SafeTypeName(type)}': {ex.Message}");
+                        $"[TypeAnalyzer] Skipping '{TypeMapper.SafeTypeName(type)}': {ex.Message}");
                 }
             }
             return results;
-        }
-
-        private static string SafeTypeName(Type type) {
-            if (type == null) return "<null>";
-            try {
-                return type.FullName ?? type.Name;
-            } catch {
-                try { return type.Name; } catch { return "<unknown>"; }
-            }
         }
 
         /// <summary>

--- a/Editor/TypeGenerator/Analysis/TypeMapper.cs
+++ b/Editor/TypeGenerator/Analysis/TypeMapper.cs
@@ -190,7 +190,7 @@ namespace OneJS.Editor.TypeGenerator {
         /// Returns the best name for the type without throwing, even when
         /// metadata access is unreliable (open generics, byref-like, etc.).
         /// </summary>
-        private static string SafeTypeName(Type type) {
+        public static string SafeTypeName(Type type) {
             if (type == null) return "<null>";
             try {
                 return type.FullName ?? type.Name;

--- a/Editor/TypeGenerator/Analysis/TypeMapper.cs
+++ b/Editor/TypeGenerator/Analysis/TypeMapper.cs
@@ -61,14 +61,26 @@ namespace OneJS.Editor.TypeGenerator {
         /// </summary>
         public static TsTypeRef MapType(Type type) {
             if (type == null) {
-                return new TsTypeRef { Name = "any", IsPrimitive = true, PrimitiveTypeName = "any" };
+                return AnyTypeRef(null);
             }
 
-            var typeRef = new TsTypeRef {
-                OriginalType = type
-            };
+            // Wrap the entire body so any reflection quirk on an exotic type
+            // (e.g. "Array type can not be an open generic type" thrown when
+            // accessing metadata of an open generic with array constituents)
+            // degrades to `any` instead of crashing the whole analysis pass.
+            try {
+                return MapTypeCore(type);
+            } catch (Exception ex) {
+                UnityEngine.Debug.LogWarning(
+                    $"[TypeMapper] Mapping '{SafeTypeName(type)}' failed, using 'any': {ex.Message}");
+                return AnyTypeRef(type);
+            }
+        }
 
-            // Handle by-ref types (ref, out, in)
+        private static TsTypeRef MapTypeCore(Type type) {
+            // Handle by-ref types first (ref, out, in) - they wrap another type.
+            // We unwrap before checking ShouldEmitAsAny so that `ref SomeType` is
+            // classified by the underlying type, not the by-ref wrapper.
             if (type.IsByRef) {
                 var elementType = type.GetElementType();
                 var innerRef = MapType(elementType);
@@ -86,6 +98,20 @@ namespace OneJS.Editor.TypeGenerator {
                     OriginalType = type
                 };
             }
+
+            // Types that would produce invalid TypeScript identifiers
+            // (compiler-generated nested types like `<buttons>e__FixedBuffer`,
+            // closure display classes, async state machines, etc.) must be
+            // mapped to `any` here as well as at the type-definition level,
+            // otherwise their raw names leak into field/property/return type
+            // signatures and produce unparseable output.
+            if (ShouldEmitAsAny(type)) {
+                return AnyTypeRef(type);
+            }
+
+            var typeRef = new TsTypeRef {
+                OriginalType = type
+            };
 
             // Handle array types
             if (type.IsArray) {
@@ -146,6 +172,31 @@ namespace OneJS.Editor.TypeGenerator {
             typeRef.Name = type.Name.Replace('`', '$');
             typeRef.Namespace = type.Namespace;
             return typeRef;
+        }
+
+        /// <summary>
+        /// Build a type ref that emits as TypeScript `any`.
+        /// </summary>
+        private static TsTypeRef AnyTypeRef(Type originalType) {
+            return new TsTypeRef {
+                Name = "any",
+                IsPrimitive = true,
+                PrimitiveTypeName = "any",
+                OriginalType = originalType
+            };
+        }
+
+        /// <summary>
+        /// Returns the best name for the type without throwing, even when
+        /// metadata access is unreliable (open generics, byref-like, etc.).
+        /// </summary>
+        private static string SafeTypeName(Type type) {
+            if (type == null) return "<null>";
+            try {
+                return type.FullName ?? type.Name;
+            } catch {
+                try { return type.Name; } catch { return "<unknown>"; }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Two real-world failures surfaced while generating typings for Unity assemblies:

1. 'Array type can not be an open generic type'

<img width="2426" height="306" alt="image" src="https://github.com/user-attachments/assets/aab7bbae-c7a3-47f5-be42-2daf8a014d3f" />

   Some types (seen in `Unity.Localization`) carry reflection metadata that the CLR refuses to materialize — accessing members, interfaces, or element types on an open generic with array constituents throws this exception. The current `TypeAnalyzer.AnalyzeTypes` loop runs `AnalyzeType(...)` without a guard, so a single failing type aborts the entire batch and the user loses typings for every other type in the same assembly.

   Fix: wrap `AnalyzeType(...)` in a per-type try/catch. A failing type is logged as a warning and skipped, letting the remaining types still emit. A SafeTypeName helper avoids secondary exceptions when FullName itself throws on the problematic type.

3. `<buttons>e__FixedBuffer` leaking into field type signatures

<img width="1968" height="378" alt="image" src="https://github.com/user-attachments/assets/ac2af818-1491-4ecb-8f4b-99bc739bea32" />

   `Unity.InputSystem.Android.LowLevel.AndroidGameControllerState` holds fixed-size buffers whose backing type is the compiler-generated nested struct `<buttons>e__FixedBuffer`. ShouldEmitAsAny already recognises these at type-definition level, so the type itself is emitted as a `type _buttons_e__FixedBuffer = any` alias — but when the parent struct has a field of that type, TypeMapper.MapType still produced a type-ref to the raw name, resulting in

```ts
       public buttons: UnityEngine.InputSystem.Android.LowLevel
                       .AndroidGameControllerState.<buttons>e__FixedBuffer;
```

   which is not valid TypeScript.

   Fix: call ShouldEmitAsAny from inside MapType too. If a referenced type would be emitted as an any-alias, map the reference to 'any' directly instead of leaking the invalid name into the signature.

   As an additional safety net, the body of MapType is split into MapTypeCore and wrapped in try/catch — any other reflection quirk on an exotic type degrades to 'any' rather than crashing the whole pass.

No changes to runtime code or public API. The `csharp.d.ts` may now contain a small number of 'any' type references or fewer entries in difficult assemblies, but the common case (hand-authored game code, Unity core, InputSystem, Localization) now generates without losing the entire assembly to one bad type.

> This PR was authored with the assistance of Claude Code. There may be edge cases I haven't caught. Please review carefully, and if you find any issues, feel free to reject the PR with a comment explaining the problem — I'll follow up and address it.
