### PR TITLE
Dispatch NavigationMove/Submit/Cancel events to JS

### DIFF
--- a/Resources/OneJS/QuickJSBootstrap.js.txt
+++ b/Resources/OneJS/QuickJSBootstrap.js.txt
@@ -1047,6 +1047,9 @@ const __EVT_POINTER_LEAVE = 15;
 const __EVT_FOCUS = 20;
 const __EVT_BLUR = 21;
 const __EVT_VIEWPORT_CHANGE = 30;
+const __EVT_NAVIGATION_MOVE = 40;
+const __EVT_NAVIGATION_SUBMIT = 41;
+const __EVT_NAVIGATION_CANCEL = 42;
 
 const __EVT_TYPE_NAMES = {
     [__EVT_CHANGE_FLOAT]: "change",
@@ -1061,7 +1064,13 @@ const __EVT_TYPE_NAMES = {
     [__EVT_FOCUS]: "focus",
     [__EVT_BLUR]: "blur",
     [__EVT_VIEWPORT_CHANGE]: "viewportchange",
+    [__EVT_NAVIGATION_MOVE]: "navigationmove",
+    [__EVT_NAVIGATION_SUBMIT]: "navigationsubmit",
+    [__EVT_NAVIGATION_CANCEL]: "navigationcancel",
 };
+
+// Mirrors UnityEngine.UIElements.NavigationMoveEvent.Direction
+const __NAV_DIRECTION_NAMES = ["none", "left", "up", "right", "down", "next", "previous"];
 
 globalThis.__dispatchEventFast = function(eventTypeId, elementHandle, a0, a1, a2, a3) {
     const eventType = __EVT_TYPE_NAMES[eventTypeId];
@@ -1077,9 +1086,15 @@ globalThis.__dispatchEventFast = function(eventTypeId, elementHandle, a0, a1, a2
     } else if (eventTypeId < 30) {
         // Focus/blur: no data
         eventData = {};
-    } else {
+    } else if (eventTypeId < 40) {
         // Viewport: a0=width, a1=height
         eventData = { width: a0, height: a1 };
+    } else if (eventTypeId === __EVT_NAVIGATION_MOVE) {
+        // Navigation move: a0 = direction enum value (0=None..6=Previous)
+        eventData = { direction: __NAV_DIRECTION_NAMES[a0] || "none" };
+    } else {
+        // Navigation submit/cancel: no payload
+        eventData = {};
     }
 
     __dispatchEvent(elementHandle, eventType, eventData);

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -416,13 +416,11 @@ public class QuickJSUIBridge : IDisposable {
 
     // Navigation events (controller / keyboard focus navigation)
     void OnNavigationMove(NavigationMoveEvent e) {
-        int handle = FindElementHandle(e.target);
-        if (handle == 0) return;
         if (_eventDispatchHandle >= 0) {
-            DispatchEventFast(EVT_NAVIGATION_MOVE, handle, (int)e.direction);
+            DispatchEventFast(EVT_NAVIGATION_MOVE, FindElementHandle(e.target), (int)e.direction);
         } else {
-            string data = $"{{\"direction\":\"{NavigationDirectionName(e.direction)}\"}}";
-            DispatchEventInternal(handle, "navigationmove", data);
+            DispatchEvent("navigationmove", e.target,
+                $"{{\"direction\":\"{NavigationDirectionName(e.direction)}\"}}");
         }
     }
 

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -41,6 +41,9 @@ public class QuickJSUIBridge : IDisposable {
     const int EVT_FOCUS = 20;
     const int EVT_BLUR = 21;
     const int EVT_VIEWPORT_CHANGE = 30;
+    const int EVT_NAVIGATION_MOVE = 40;
+    const int EVT_NAVIGATION_SUBMIT = 41;
+    const int EVT_NAVIGATION_CANCEL = 42;
 
     // Viewport tracking for responsive design
     float _lastViewportWidth;
@@ -297,6 +300,9 @@ public class QuickJSUIBridge : IDisposable {
         _root.RegisterCallback<FocusOutEvent>(OnFocusOut, TrickleDown.TrickleDown);
         _root.RegisterCallback<KeyDownEvent>(OnKeyDown, TrickleDown.TrickleDown);
         _root.RegisterCallback<KeyUpEvent>(OnKeyUp, TrickleDown.TrickleDown);
+        _root.RegisterCallback<NavigationMoveEvent>(OnNavigationMove, TrickleDown.TrickleDown);
+        _root.RegisterCallback<NavigationSubmitEvent>(OnNavigationSubmit, TrickleDown.TrickleDown);
+        _root.RegisterCallback<NavigationCancelEvent>(OnNavigationCancel, TrickleDown.TrickleDown);
         _root.RegisterCallback<ChangeEvent<string>>(OnChangeString, TrickleDown.TrickleDown);
         _root.RegisterCallback<ChangeEvent<bool>>(OnChangeBool, TrickleDown.TrickleDown);
         _root.RegisterCallback<ChangeEvent<float>>(OnChangeFloat, TrickleDown.TrickleDown);
@@ -315,6 +321,9 @@ public class QuickJSUIBridge : IDisposable {
         _root.UnregisterCallback<FocusOutEvent>(OnFocusOut, TrickleDown.TrickleDown);
         _root.UnregisterCallback<KeyDownEvent>(OnKeyDown, TrickleDown.TrickleDown);
         _root.UnregisterCallback<KeyUpEvent>(OnKeyUp, TrickleDown.TrickleDown);
+        _root.UnregisterCallback<NavigationMoveEvent>(OnNavigationMove, TrickleDown.TrickleDown);
+        _root.UnregisterCallback<NavigationSubmitEvent>(OnNavigationSubmit, TrickleDown.TrickleDown);
+        _root.UnregisterCallback<NavigationCancelEvent>(OnNavigationCancel, TrickleDown.TrickleDown);
         _root.UnregisterCallback<ChangeEvent<string>>(OnChangeString, TrickleDown.TrickleDown);
         _root.UnregisterCallback<ChangeEvent<bool>>(OnChangeBool, TrickleDown.TrickleDown);
         _root.UnregisterCallback<ChangeEvent<float>>(OnChangeFloat, TrickleDown.TrickleDown);
@@ -404,6 +413,44 @@ public class QuickJSUIBridge : IDisposable {
     // Key events stay on eval path (need string args)
     void OnKeyDown(KeyDownEvent e) => DispatchKeyEvent("keydown", e.target, e.keyCode, e.character, e.modifiers);
     void OnKeyUp(KeyUpEvent e) => DispatchKeyEvent("keyup", e.target, e.keyCode, '\0', e.modifiers);
+
+    // Navigation events (controller / keyboard focus navigation)
+    void OnNavigationMove(NavigationMoveEvent e) {
+        int handle = FindElementHandle(e.target);
+        if (handle == 0) return;
+        if (_eventDispatchHandle >= 0) {
+            DispatchEventFast(EVT_NAVIGATION_MOVE, handle, (int)e.direction);
+        } else {
+            string data = $"{{\"direction\":\"{NavigationDirectionName(e.direction)}\"}}";
+            DispatchEventInternal(handle, "navigationmove", data);
+        }
+    }
+
+    void OnNavigationSubmit(NavigationSubmitEvent e) {
+        if (_eventDispatchHandle >= 0) {
+            DispatchEventFast(EVT_NAVIGATION_SUBMIT, FindElementHandle(e.target));
+        } else {
+            DispatchEvent("navigationsubmit", e.target, "{}");
+        }
+    }
+
+    void OnNavigationCancel(NavigationCancelEvent e) {
+        if (_eventDispatchHandle >= 0) {
+            DispatchEventFast(EVT_NAVIGATION_CANCEL, FindElementHandle(e.target));
+        } else {
+            DispatchEvent("navigationcancel", e.target, "{}");
+        }
+    }
+
+    static string NavigationDirectionName(NavigationMoveEvent.Direction d) => d switch {
+        NavigationMoveEvent.Direction.Left => "left",
+        NavigationMoveEvent.Direction.Up => "up",
+        NavigationMoveEvent.Direction.Right => "right",
+        NavigationMoveEvent.Direction.Down => "down",
+        NavigationMoveEvent.Direction.Next => "next",
+        NavigationMoveEvent.Direction.Previous => "previous",
+        _ => "none",
+    };
 
     // String change events stay on eval path (need string value)
     void OnChangeString(ChangeEvent<string> e) {


### PR DESCRIPTION
## My Problem
- UI Toolkit's `NavigationMoveEvent` / `NavigationSubmitEvent` / `NavigationCancelEvent` weren't reaching JS.
- so `onNavigationMove` / `onNavigationSubmit` / `onNavigationCancel` props on React-side components never fired.

## What I Changed
- This PR wires them through the existing per-element dispatch path so they surface as `navigationmove` / `navigationsubmit` / `navigationcancel` on the JS side.