### PR TITLE
Honor C# default-valued parameters when dispatching from JS

### DIFF
--- a/Runtime/QuickJSNative.Dispatch.cs
+++ b/Runtime/QuickJSNative.Dispatch.cs
@@ -297,11 +297,28 @@ public static partial class QuickJSNative {
                     }
 
                     var parms = method.GetParameters();
-                    for (int i = 0; i < parms.Length; i++) {
-                        args[i] = ConvertToTargetType(args[i], parms[i].ParameterType);
+                    object[] invokeArgs;
+                    if (parms.Length == args.Length) {
+                        for (int i = 0; i < parms.Length; i++) {
+                            args[i] = ConvertToTargetType(args[i], parms[i].ParameterType);
+                        }
+                        invokeArgs = args;
+                    } else {
+                        // FindMethod matched an optional-parameter overload where
+                        // the caller omitted trailing args. Fill the missing
+                        // slots with the declared default values.
+                        invokeArgs = new object[parms.Length];
+                        for (int i = 0; i < args.Length; i++) {
+                            invokeArgs[i] = ConvertToTargetType(args[i], parms[i].ParameterType);
+                        }
+                        for (int i = args.Length; i < parms.Length; i++) {
+                            invokeArgs[i] = parms[i].HasDefaultValue
+                                ? parms[i].DefaultValue
+                                : Type.Missing;
+                        }
                     }
 
-                    object result = method.Invoke(isStatic ? null : target, args);
+                    object result = method.Invoke(isStatic ? null : target, invokeArgs);
                     SetReturnValue(resPtr, result);
                     return;
                 }

--- a/Runtime/QuickJSNative.Reflection.cs
+++ b/Runtime/QuickJSNative.Reflection.cs
@@ -112,21 +112,43 @@ public static partial class QuickJSNative {
     }
 
     static MethodInfo FindMethod(Type type, string name, BindingFlags flags, object[] args) {
+        // Prefer an exact arity/type match. Fall back to a method that declares
+        // additional trailing parameters where every extra has a C# default
+        // value — this lets JS callers omit optional trailing arguments, e.g.
+        //   audioManager.PlaySfx("UI/Submit")
+        // binds to `PlaySfx(string key, float volumeScale = 1, float pitch = 1)`.
+        // The invoke site (QuickJSNative.Dispatch) fills the missing slots with
+        // the declared default values.
+        MethodInfo optionalParamFallback = null;
+
         while (type != null) {
             foreach (var m in type.GetMethods(flags | BindingFlags.DeclaredOnly)) {
                 if (m.Name != name) continue;
                 var parameters = m.GetParameters();
-                if (parameters.Length != args.Length) continue;
 
-                bool match = true;
-                for (int j = 0; j < parameters.Length && match; j++)
-                    match = IsArgCompatible(parameters[j].ParameterType, args[j]);
+                if (parameters.Length == args.Length) {
+                    bool match = true;
+                    for (int j = 0; j < parameters.Length && match; j++)
+                        match = IsArgCompatible(parameters[j].ParameterType, args[j]);
+                    if (match) return m;
+                    continue;
+                }
 
-                if (match) return m;
+                if (parameters.Length > args.Length && optionalParamFallback == null) {
+                    bool match = true;
+                    for (int j = 0; j < args.Length && match; j++)
+                        match = IsArgCompatible(parameters[j].ParameterType, args[j]);
+                    if (match) {
+                        for (int j = args.Length; j < parameters.Length && match; j++)
+                            match = parameters[j].HasDefaultValue;
+                        if (match) optionalParamFallback = m;
+                    }
+                }
             }
             type = type.BaseType;
         }
-        return null;
+
+        return optionalParamFallback;
     }
 
     static PropertyInfo FindProperty(Type type, string name, BindingFlags flags) {

--- a/Runtime/QuickJSNative.Reflection.cs
+++ b/Runtime/QuickJSNative.Reflection.cs
@@ -294,7 +294,7 @@ public static partial class QuickJSNative {
     // MARK: Cached Lookups
     static MethodInfo FindMethodCached(Type type, string name, bool isStatic, object[] args) {
         var key = (type, name, isStatic, ComputeArgTypeHash(args));
-        if (_methodCache.TryGetValue(key, out var cached) && cached.GetParameters().Length == args.Length)
+        if (_methodCache.TryGetValue(key, out var cached) && cached.GetParameters().Length >= args.Length)
             return cached;
 
         var method = FindMethod(type, name, GetFlags(isStatic), args);


### PR DESCRIPTION
## My Problem

```cs
    /// <summary>
    /// SFX를 재생한다. 같은 키는 0.1초 내 중복 재생 차단.
    /// </summary>
    public void PlaySfx(string key, float volumeScale = 1f, float pitch = 1f)
    {
       ...
    }
```
```ts
audioManager.PlaySfx("UI/Submit") // error: Method AudioManager.PlaySfx(string) not found
audioManager.PlaySfx("UI/Submit", 1, 1) // works well
```
- `FindMethod` required an exact arg-count match.
- so calling a C# method with trailing `HasDefaultValue` parameters from JS failed with `Method not found` unless the caller filled every slot.

## What I Changed

- Fallback order is now:
   1. Exact parameter-count match (unchanged)
   2. Method whose `parameters.Length > args.Length` and every extra parameter has a default value
- When the optional overload wins, missing slots are filled with `parms[i].DefaultValue` (or `Type.Missing` as a last resort) before `Invoke`.

## Note

Stacked on #99: `feature/insd47/navigation-events` — please merge that first.