### PR TITLE
Mouse-wheel bridging + native event suppression

### DIFF
--- a/Plugins/WebGL/OneJSWebGL.jslib
+++ b/Plugins/WebGL/OneJSWebGL.jslib
@@ -586,18 +586,20 @@ var OneJSWebGLLib = {
 
     qjs_dispatch_event__deps: ["$OneJS"],
     qjs_dispatch_event: function(elementHandle, eventTypePtr, eventDataPtr) {
-        // Fast path for event dispatch - avoids eval overhead
+        // Fast path for event dispatch - avoids eval overhead. Returns the suppression-flags
+        // bitmask from __dispatchEvent (bit0=propagationStopped, bit1=defaultPrevented), or 0.
         var eventType = UTF8ToString(eventTypePtr);
         var eventDataJson = UTF8ToString(eventDataPtr);
 
         try {
             var eventData = eventDataJson ? JSON.parse(eventDataJson) : {};
             if (typeof __dispatchEvent === "function") {
-                __dispatchEvent(elementHandle, eventType, eventData);
+                return __dispatchEvent(elementHandle, eventType, eventData) | 0;
             }
         } catch (e) {
             console.error("[OneJS] Event dispatch error:", e);
         }
+        return 0;
     }
 };
 

--- a/Resources/OneJS/QuickJSBootstrap.js.txt
+++ b/Resources/OneJS/QuickJSBootstrap.js.txt
@@ -1069,6 +1069,10 @@ globalThis.__dispatchEvent = function(elementHandle, eventType, eventData) {
             currentHandle = __parentMap.get(currentHandle);
         }
     }
+
+    // Return suppression flags so the C# bridge can mirror them onto the native event.
+    // bit0 = propagationStopped (JS bubble only); bit1 = defaultPrevented (-> native suppression).
+    return (event.propagationStopped ? 1 : 0) | (event.defaultPrevented ? 2 : 0);
 };
 
 /**
@@ -1114,7 +1118,7 @@ const __NAV_DIRECTION_NAMES = ["none", "left", "up", "right", "down", "next", "p
 
 globalThis.__dispatchEventFast = function(eventTypeId, elementHandle, a0, a1, a2, a3) {
     const eventType = __EVT_TYPE_NAMES[eventTypeId];
-    if (!eventType) return;
+    if (!eventType) return 0;
 
     var eventData;
     if (eventTypeId <= 3) {
@@ -1137,7 +1141,7 @@ globalThis.__dispatchEventFast = function(eventTypeId, elementHandle, a0, a1, a2
         eventData = {};
     }
 
-    __dispatchEvent(elementHandle, eventType, eventData);
+    return __dispatchEvent(elementHandle, eventType, eventData);
 };
 
 // Expose event API

--- a/Runtime/QuickJSContext.cs
+++ b/Runtime/QuickJSContext.cs
@@ -348,4 +348,30 @@ public sealed class QuickJSContext : IDisposable {
         var args = stackalloc QuickJSNative.InteropValue[6] { MakeInt(arg0), MakeInt(arg1), MakeFloat(arg2), MakeFloat(arg3), MakeInt(arg4), MakeInt(arg5) };
         InvokeAndCheck(handle, args, 6);
     }
+
+    // Like InvokeAndCheck but reads the marshaled int result instead of discarding it.
+    // Used by the fast event-dispatch path to read suppression flags. Allocation-free
+    // for an int/number return (the JS dispatch returns a small bitmask).
+    unsafe int InvokeAndGetInt(int handle, QuickJSNative.InteropValue* args, int count) {
+        QuickJSNative.InteropValue result = default;
+        int code = QuickJSNative.qjs_invoke_callback(_ptr, handle, args, count, &result);
+        if (code != 0) throw new Exception($"qjs_invoke_callback failed with code {code}");
+        switch (result.type) {
+            case QuickJSNative.InteropType.Int32: return result.i32;
+            case QuickJSNative.InteropType.Double: return (int)result.f64;
+            case QuickJSNative.InteropType.Float32: return (int)result.f32;
+            default: return 0;
+        }
+    }
+
+    /// <summary>
+    /// Invoke a callback (2 int + 2 float + 2 int args) and return its int result.
+    /// ZERO ALLOCATION. Mirror of the 6-arg InvokeCallbackNoAlloc, but surfaces the
+    /// JS return value (event-dispatch suppression flags) to C#.
+    /// </summary>
+    public unsafe int InvokeCallbackReturnInt(int handle, int arg0, int arg1, float arg2, float arg3, int arg4, int arg5) {
+        ThrowIfInvalid();
+        var args = stackalloc QuickJSNative.InteropValue[6] { MakeInt(arg0), MakeInt(arg1), MakeFloat(arg2), MakeFloat(arg3), MakeInt(arg4), MakeInt(arg5) };
+        return InvokeAndGetInt(handle, args, 6);
+    }
 }

--- a/Runtime/QuickJSContext.cs
+++ b/Runtime/QuickJSContext.cs
@@ -356,12 +356,24 @@ public sealed class QuickJSContext : IDisposable {
         QuickJSNative.InteropValue result = default;
         int code = QuickJSNative.qjs_invoke_callback(_ptr, handle, args, count, &result);
         if (code != 0) throw new Exception($"qjs_invoke_callback failed with code {code}");
+
+        int value;
         switch (result.type) {
-            case QuickJSNative.InteropType.Int32: return result.i32;
-            case QuickJSNative.InteropType.Double: return (int)result.f64;
-            case QuickJSNative.InteropType.Float32: return (int)result.f32;
-            default: return 0;
+            case QuickJSNative.InteropType.Int32: value = result.i32; break;
+            case QuickJSNative.InteropType.Double: value = (int)result.f64; break;
+            case QuickJSNative.InteropType.Float32: value = (int)result.f32; break;
+            default: value = 0; break;
         }
+
+        // Defensive: this path only ever returns a small int bitmask, but if a handler
+        // returns a string/object the native side allocates a CoTaskMem buffer in `str`;
+        // free it instead of leaking (mirrors the InvokeAndCheck result handling).
+        if ((result.type == QuickJSNative.InteropType.String ||
+             result.type == QuickJSNative.InteropType.JsonObject) && result.str != IntPtr.Zero) {
+            Marshal.FreeCoTaskMem(result.str);
+        }
+
+        return value;
     }
 
     /// <summary>

--- a/Runtime/QuickJSNative.cs
+++ b/Runtime/QuickJSNative.cs
@@ -110,9 +110,10 @@ public static partial class QuickJSNative {
     internal static extern void qjs_set_cs_zeroalloc_callback(CsZeroAllocCallback cb);
 
 #if UNITY_WEBGL && !UNITY_EDITOR
-    // Fast event dispatch for WebGL - avoids eval overhead
+    // Fast event dispatch for WebGL - avoids eval overhead. Returns the suppression-flags
+    // bitmask from __dispatchEvent (bit0=propagationStopped, bit1=defaultPrevented), or 0.
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    internal static extern void qjs_dispatch_event(
+    internal static extern int qjs_dispatch_event(
         int elementHandle,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string eventType,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string eventDataJson

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -361,47 +361,48 @@ public class QuickJSUIBridge : IDisposable {
 
     // MARK: Event Handlers
 
+    // JS preventDefault() (defaultPrevented, bit1) is mirrored onto the native event as
+    // StopImmediatePropagation, so a JS gesture can suppress nested native controls (e.g. a
+    // ScrollView's pan/scroll). stopPropagation() (bit0) stays JS-bubble-only and is NOT
+    // mirrored, preserving behavior for handlers that only stop the JS-side bubble.
+    const int FLAG_DEFAULT_PREVENTED = 2;
+    static void ApplyNativeSuppression(EventBase e, int flags) {
+        if ((flags & FLAG_DEFAULT_PREVENTED) != 0) e.StopImmediatePropagation();
+    }
+
     void OnClick(ClickEvent e) {
-        if (_eventDispatchHandle >= 0) {
-            int handle = FindElementHandle(e.target);
-            DispatchEventFast(EVT_CLICK, handle, e.position.x, e.position.y, e.button, 0);
-        } else {
-            DispatchPointerEvent("click", e.target, e.position, e.button);
-        }
+        int flags = _eventDispatchHandle >= 0
+            ? DispatchEventFast(EVT_CLICK, FindElementHandle(e.target), e.position.x, e.position.y, e.button, 0)
+            : DispatchPointerEvent("click", e.target, e.position, e.button);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPointerDown(PointerDownEvent e) {
         if (e.timestamp == _lastDispatchedPointerDownTs) return;
         _lastDispatchedPointerDownTs = e.timestamp;
-        if (_eventDispatchHandle >= 0) {
-            int handle = FindElementHandle(e.target);
-            DispatchEventFast(EVT_POINTER_DOWN, handle, e.position.x, e.position.y, e.button, e.pointerId);
-        } else {
-            DispatchPointerEvent("pointerdown", e.target, e.position, e.button, e.pointerId);
-        }
+        int flags = _eventDispatchHandle >= 0
+            ? DispatchEventFast(EVT_POINTER_DOWN, FindElementHandle(e.target), e.position.x, e.position.y, e.button, e.pointerId)
+            : DispatchPointerEvent("pointerdown", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPointerUp(PointerUpEvent e) {
         if (e.timestamp == _lastDispatchedPointerUpTs) return;
         _lastDispatchedPointerUpTs = e.timestamp;
-        if (_eventDispatchHandle >= 0) {
-            int handle = FindElementHandle(e.target);
-            DispatchEventFast(EVT_POINTER_UP, handle, e.position.x, e.position.y, e.button, e.pointerId);
-        } else {
-            DispatchPointerEvent("pointerup", e.target, e.position, e.button, e.pointerId);
-        }
+        int flags = _eventDispatchHandle >= 0
+            ? DispatchEventFast(EVT_POINTER_UP, FindElementHandle(e.target), e.position.x, e.position.y, e.button, e.pointerId)
+            : DispatchPointerEvent("pointerup", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPointerMove(PointerMoveEvent e) {
         if (!InputBridge.PointerMoveEventsEnabled) return;
         if (e.timestamp == _lastDispatchedPointerMoveTs) return;
         _lastDispatchedPointerMoveTs = e.timestamp;
-        if (_eventDispatchHandle >= 0) {
-            int handle = FindElementHandle(e.target);
-            DispatchEventFast(EVT_POINTER_MOVE, handle, e.position.x, e.position.y, e.button, e.pointerId);
-        } else {
-            DispatchPointerEvent("pointermove", e.target, e.position, e.button, e.pointerId);
-        }
+        int flags = _eventDispatchHandle >= 0
+            ? DispatchEventFast(EVT_POINTER_MOVE, FindElementHandle(e.target), e.position.x, e.position.y, e.button, e.pointerId)
+            : DispatchPointerEvent("pointermove", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPointerEnter(PointerEnterEvent e) {
@@ -454,7 +455,8 @@ public class QuickJSUIBridge : IDisposable {
     // TrickleDown handler fires (wheel has no per-element/capture handler), so no
     // timestamp dedup is needed. WheelEvent.delta is a Vector3; the z component is unused.
     void OnWheel(WheelEvent e) {
-        DispatchWheelEvent("wheel", e.target, e.delta);
+        int flags = DispatchWheelEvent("wheel", e.target, e.delta);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnFocusIn(FocusInEvent e) {
@@ -584,11 +586,14 @@ public class QuickJSUIBridge : IDisposable {
     /// <summary>
     /// Core dispatch method - all event dispatching goes through here.
     /// </summary>
-    void DispatchEventInternal(int handle, string eventType, string dataJson) {
-        if (handle == 0 || _inEval) return;
+    // Returns the suppression-flags bitmask from __dispatchEvent (bit0=propagationStopped,
+    // bit1=defaultPrevented), or 0 if nothing was dispatched.
+    int DispatchEventInternal(int handle, string eventType, string dataJson) {
+        if (handle == 0 || _inEval) return 0;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
         QuickJSNative.qjs_dispatch_event(handle, eventType, dataJson);
+        return 0; // WebGL flag return is Phase 3 (needs qjs_dispatch_event to return int)
 #else
         _sb.Clear();
         _sb.Append("globalThis.__dispatchEvent && __dispatchEvent(");
@@ -603,10 +608,13 @@ public class QuickJSUIBridge : IDisposable {
         // during React reconciliation (matches DispatchEventFast semantics).
         _inEval = true;
         try {
-            _ctx.Eval(_sb.ToString());
+            // __dispatchEvent returns the suppression-flags bitmask; the eval result carries it.
+            string result = _ctx.Eval(_sb.ToString());
             _ctx.ExecutePendingJobs();
+            return (result != null && int.TryParse(result, out int flags)) ? flags : 0;
         } catch (Exception ex) {
             Debug.LogWarning($"[QuickJSUIBridge] Event dispatch error: {ex.Message}\nEval: {_sb}");
+            return 0;
         } finally {
             _inEval = false;
         }
@@ -648,14 +656,18 @@ public class QuickJSUIBridge : IDisposable {
         } finally { _inEval = false; }
     }
 
-    void DispatchEventFast(int eventTypeId, int elemHandle, float x, float y, int button, int pointerId) {
-        if (elemHandle == 0 || _inEval) return;
+    // Pointer/click fast path. Returns the suppression-flags bitmask from the JS dispatch
+    // (bit0=propagationStopped, bit1=defaultPrevented), or 0.
+    int DispatchEventFast(int eventTypeId, int elemHandle, float x, float y, int button, int pointerId) {
+        if (elemHandle == 0 || _inEval) return 0;
         _inEval = true;
         try {
-            _ctx.InvokeCallbackNoAlloc(_eventDispatchHandle, eventTypeId, elemHandle, x, y, button, pointerId);
+            int flags = _ctx.InvokeCallbackReturnInt(_eventDispatchHandle, eventTypeId, elemHandle, x, y, button, pointerId);
             _ctx.ExecutePendingJobs();
+            return flags;
         } catch (Exception ex) {
             Debug.LogWarning($"[QuickJSUIBridge] Event dispatch error ({eventTypeId}): {ex.Message}");
+            return 0;
         } finally { _inEval = false; }
     }
 
@@ -673,23 +685,23 @@ public class QuickJSUIBridge : IDisposable {
     /// <summary>
     /// Dispatch an event with pre-built JSON data.
     /// </summary>
-    void DispatchEvent(string eventType, IEventHandler target, string dataJson) {
+    int DispatchEvent(string eventType, IEventHandler target, string dataJson) {
         int handle = FindElementHandle(target);
-        DispatchEventInternal(handle, eventType, dataJson);
+        return DispatchEventInternal(handle, eventType, dataJson);
     }
 
     /// <summary>
     /// Dispatch a pointer event with position and button data.
     /// </summary>
-    void DispatchPointerEvent(string eventType, IEventHandler target, Vector2 position, int button, int pointerId = 0) {
+    int DispatchPointerEvent(string eventType, IEventHandler target, Vector2 position, int button, int pointerId = 0) {
         int handle = FindElementHandle(target);
-        if (handle == 0) return;
+        if (handle == 0) return 0;
 
         string data = string.Format(CultureInfo.InvariantCulture,
             "{{\"x\":{0:F2},\"y\":{1:F2},\"button\":{2},\"pointerId\":{3}}}",
             position.x, position.y, button, pointerId);
 
-        DispatchEventInternal(handle, eventType, data);
+        return DispatchEventInternal(handle, eventType, data);
     }
 
     /// <summary>
@@ -697,9 +709,9 @@ public class QuickJSUIBridge : IDisposable {
     /// (z is unused); exposed to JS as flat { deltaX, deltaY } to mirror the DOM WheelEvent
     /// (e.deltaX / e.deltaY) and to keep the event-data object flat like the other events.
     /// </summary>
-    void DispatchWheelEvent(string eventType, IEventHandler target, Vector3 delta) {
+    int DispatchWheelEvent(string eventType, IEventHandler target, Vector3 delta) {
         int handle = FindElementHandle(target);
-        if (handle == 0) return;
+        if (handle == 0) return 0;
 
         // Avoid `string.Format` here: a trailing `{1:F4}}}` (format-spec placeholder
         // followed by `}}`) is parsed inconsistently on Mono and corrupts the final
@@ -709,7 +721,7 @@ public class QuickJSUIBridge : IDisposable {
                     + ",\"deltaY\":" + delta.y.ToString("F4", inv)
                     + "}";
 
-        DispatchEventInternal(handle, eventType, data);
+        return DispatchEventInternal(handle, eventType, data);
     }
 
     /// <summary>

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -330,6 +330,7 @@ public class QuickJSUIBridge : IDisposable {
         _root.RegisterCallback<ChangeEvent<float>>(OnChangeFloat, TrickleDown.TrickleDown);
         _root.RegisterCallback<ChangeEvent<int>>(OnChangeInt, TrickleDown.TrickleDown);
         _root.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+        _root.RegisterCallback<WheelEvent>(OnWheel, TrickleDown.TrickleDown);
     }
 
     void UnregisterEventDelegation() {
@@ -355,6 +356,7 @@ public class QuickJSUIBridge : IDisposable {
         _root.UnregisterCallback<ChangeEvent<float>>(OnChangeFloat, TrickleDown.TrickleDown);
         _root.UnregisterCallback<ChangeEvent<int>>(OnChangeInt, TrickleDown.TrickleDown);
         _root.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+        _root.UnregisterCallback<WheelEvent>(OnWheel, TrickleDown.TrickleDown);
     }
 
     // MARK: Event Handlers
@@ -445,6 +447,14 @@ public class QuickJSUIBridge : IDisposable {
         if (e.timestamp == _lastDispatchedPointerCaptureOutTs) return;
         _lastDispatchedPointerCaptureOutTs = e.timestamp;
         DispatchPointerCaptureEvent("pointercaptureout", e.target, e.pointerId);
+    }
+
+    // Mouse wheel / trackpad scroll. Like the cancel/capture handlers above, this stays
+    // on the string dispatch path (it is not per-frame like pointermove). Only the root
+    // TrickleDown handler fires (wheel has no per-element/capture handler), so no
+    // timestamp dedup is needed. WheelEvent.delta is a Vector3; the z component is unused.
+    void OnWheel(WheelEvent e) {
+        DispatchWheelEvent("wheel", e.target, e.delta);
     }
 
     void OnFocusIn(FocusInEvent e) {
@@ -678,6 +688,26 @@ public class QuickJSUIBridge : IDisposable {
         string data = string.Format(CultureInfo.InvariantCulture,
             "{{\"x\":{0:F2},\"y\":{1:F2},\"button\":{2},\"pointerId\":{3}}}",
             position.x, position.y, button, pointerId);
+
+        DispatchEventInternal(handle, eventType, data);
+    }
+
+    /// <summary>
+    /// Dispatch a wheel event carrying the scroll delta. WheelEvent.delta is a Vector3
+    /// (z is unused); exposed to JS as flat { deltaX, deltaY } to mirror the DOM WheelEvent
+    /// (e.deltaX / e.deltaY) and to keep the event-data object flat like the other events.
+    /// </summary>
+    void DispatchWheelEvent(string eventType, IEventHandler target, Vector3 delta) {
+        int handle = FindElementHandle(target);
+        if (handle == 0) return;
+
+        // Avoid `string.Format` here: a trailing `{1:F4}}}` (format-spec placeholder
+        // followed by `}}`) is parsed inconsistently on Mono and corrupts the final
+        // field, same hazard documented in RectToJson. Plain `.ToString` sidesteps it.
+        var inv = CultureInfo.InvariantCulture;
+        string data = "{\"deltaX\":" + delta.x.ToString("F4", inv)
+                    + ",\"deltaY\":" + delta.y.ToString("F4", inv)
+                    + "}";
 
         DispatchEventInternal(handle, eventType, data);
     }

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -852,35 +852,46 @@ public class QuickJSUIBridge : IDisposable {
         // during bridge disposal, so explicit unregistration is not needed here.
     }
 
+    // Per-element handlers fire during pointer capture, when the captured element
+    // receives events directly and the _root TrickleDown handler may not run (see the
+    // dedup note above). They mirror the root handlers' suppression wiring so
+    // preventDefault() keeps suppressing native controls mid-drag, not just on the
+    // initial press. When both _root and per-element fire, the timestamp dedup makes
+    // this a no-op (the root handler already applied suppression).
     void OnPerElementPointerDown(PointerDownEvent e) {
         if (e.timestamp == _lastDispatchedPointerDownTs) return;
         _lastDispatchedPointerDownTs = e.timestamp;
-        DispatchPointerEvent("pointerdown", e.target, e.position, e.button, e.pointerId);
+        int flags = DispatchPointerEvent("pointerdown", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPerElementPointerUp(PointerUpEvent e) {
         if (e.timestamp == _lastDispatchedPointerUpTs) return;
         _lastDispatchedPointerUpTs = e.timestamp;
-        DispatchPointerEvent("pointerup", e.target, e.position, e.button, e.pointerId);
+        int flags = DispatchPointerEvent("pointerup", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPerElementPointerMove(PointerMoveEvent e) {
         if (!InputBridge.PointerMoveEventsEnabled) return;
         if (e.timestamp == _lastDispatchedPointerMoveTs) return;
         _lastDispatchedPointerMoveTs = e.timestamp;
-        DispatchPointerEvent("pointermove", e.target, e.position, e.button, e.pointerId);
+        int flags = DispatchPointerEvent("pointermove", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPerElementPointerCancel(PointerCancelEvent e) {
         if (e.timestamp == _lastDispatchedPointerCancelTs) return;
         _lastDispatchedPointerCancelTs = e.timestamp;
-        DispatchPointerEvent("pointercancel", e.target, e.position, e.button, e.pointerId);
+        int flags = DispatchPointerEvent("pointercancel", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPerElementPointerStationary(PointerStationaryEvent e) {
         if (e.timestamp == _lastDispatchedPointerStationaryTs) return;
         _lastDispatchedPointerStationaryTs = e.timestamp;
-        DispatchPointerEvent("pointerstationary", e.target, e.position, e.button, e.pointerId);
+        int flags = DispatchPointerEvent("pointerstationary", e.target, e.position, e.button, e.pointerId);
+        ApplyNativeSuppression(e, flags);
     }
 
     void OnPerElementPointerCapture(PointerCaptureEvent e) {

--- a/Runtime/QuickJSUIBridge.cs
+++ b/Runtime/QuickJSUIBridge.cs
@@ -592,8 +592,9 @@ public class QuickJSUIBridge : IDisposable {
         if (handle == 0 || _inEval) return 0;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
-        QuickJSNative.qjs_dispatch_event(handle, eventType, dataJson);
-        return 0; // WebGL flag return is Phase 3 (needs qjs_dispatch_event to return int)
+        // qjs_dispatch_event returns the suppression-flags bitmask (bit0=propagationStopped,
+        // bit1=defaultPrevented), so preventDefault() suppresses native behavior on WebGL too.
+        return QuickJSNative.qjs_dispatch_event(handle, eventType, dataJson);
 #else
         _sb.Clear();
         _sb.Append("globalThis.__dispatchEvent && __dispatchEvent(");

--- a/Tests/QuickJSUIBridgePlaymodeTests.cs
+++ b/Tests/QuickJSUIBridgePlaymodeTests.cs
@@ -414,88 +414,11 @@ public class QuickJSUIBridgePlaymodeTests {
         _bridge.Eval("globalThis.__pmCaptureTestEl.ReleasePointer(0)");
     }
 
-    // MARK: Native Event Suppression + Wheel (confirmation for PR #104)
-    // These validate the planned design BEFORE it is wired into JS:
-    //  - A TrickleDown handler on the bridge root that calls StopImmediatePropagation()
-    //    prevents descendant elements (e.g. a nested ScrollView) from acting. This is the
-    //    mechanism the planned `preventDefault -> StopImmediatePropagation` will rely on.
-    //  - The bridge currently does NOT dispatch WheelEvent to JS (wheel is unbridged).
-
-    [UnityTest]
-    public IEnumerator Suppression_RootTrickleDownStop_PreventsDescendantPointerDown() {
-        var root = _uiDocument.rootVisualElement;
-
-        var child = new VisualElement { name = "SuppressChild" };
-        child.style.width = 100;
-        child.style.height = 100;
-        root.Add(child);
-        yield return null; // layout
-
-        bool childGotDown = false;
-        child.RegisterCallback<PointerDownEvent>(_ => childGotDown = true);
-
-        // Baseline: with nothing intercepting, the descendant receives PointerDown.
-        using (var evt = PointerDownEvent.GetPooled()) {
-            evt.target = child;
-            root.SendEvent(evt);
-        }
-        Assert.IsTrue(childGotDown,
-            "Baseline: descendant should receive PointerDown when nothing intercepts it.");
-
-        // Fix mechanism: a TrickleDown handler on root that stops immediate propagation
-        // must prevent the descendant from receiving the event at all.
-        childGotDown = false;
-        EventCallback<PointerDownEvent> stopper = e => e.StopImmediatePropagation();
-        root.RegisterCallback(stopper, TrickleDown.TrickleDown);
-        using (var evt = PointerDownEvent.GetPooled()) {
-            evt.target = child;
-            root.SendEvent(evt);
-        }
-        root.UnregisterCallback(stopper, TrickleDown.TrickleDown);
-
-        Assert.IsFalse(childGotDown,
-            "Fix: StopImmediatePropagation() in a root TrickleDown handler must prevent the " +
-            "descendant from receiving PointerDown. This is the path that lets a JS gesture " +
-            "suppress a nested ScrollView's native pan.");
-        yield return null;
-    }
-
-    [UnityTest]
-    public IEnumerator Suppression_RootTrickleDownStop_StopsScrollViewWheelScroll() {
-        var root = _uiDocument.rootVisualElement;
-
-        var sv = new ScrollView(ScrollViewMode.Vertical);
-        sv.style.width = 200;
-        sv.style.height = 200;
-        var content = new VisualElement { name = "TallContent" };
-        content.style.height = 2000; // taller than the viewport, so it can scroll
-        sv.Add(content);
-        root.Add(sv);
-        yield return null;
-        yield return null; // a couple frames for layout
-
-        // Baseline: a positive wheel delta scrolls the ScrollView down.
-        sv.scrollOffset = Vector2.zero;
-        SendWheel(root, content, 50f);
-        yield return null;
-        float scrolled = sv.scrollOffset.y;
-        Assert.Greater(scrolled, 0f,
-            $"Baseline: ScrollView should scroll on a wheel delta. (scrollOffset.y = {scrolled})");
-
-        // Fix mechanism: root TrickleDown StopImmediatePropagation must keep scrollOffset put.
-        sv.scrollOffset = Vector2.zero;
-        EventCallback<WheelEvent> stopper = e => e.StopImmediatePropagation();
-        root.RegisterCallback(stopper, TrickleDown.TrickleDown);
-        SendWheel(root, content, 50f);
-        yield return null;
-        float suppressed = sv.scrollOffset.y;
-        root.UnregisterCallback(stopper, TrickleDown.TrickleDown);
-
-        Assert.AreEqual(0f, suppressed, 0.0001f,
-            "Fix: with StopImmediatePropagation() in a root TrickleDown WheelEvent handler, the " +
-            $"ScrollView must not scroll. (scrollOffset.y = {suppressed})");
-        yield return null;
-    }
+    // MARK: Native Event Suppression + Wheel (PR #104)
+    // End-to-end tests for the wired feature: wheel is bridged to JS, and a JS
+    // preventDefault() maps to native StopImmediatePropagation() to suppress nested
+    // controls. Covers the root fast path, the per-element captured-pointer path, and
+    // the wheel -> ScrollView path.
 
     [UnityTest]
     public IEnumerator Wheel_DispatchedToJsHandlerWithDelta() {

--- a/Tests/QuickJSUIBridgePlaymodeTests.cs
+++ b/Tests/QuickJSUIBridgePlaymodeTests.cs
@@ -414,6 +414,143 @@ public class QuickJSUIBridgePlaymodeTests {
         _bridge.Eval("globalThis.__pmCaptureTestEl.ReleasePointer(0)");
     }
 
+    // MARK: Native Event Suppression + Wheel (confirmation for PR #104)
+    // These validate the planned design BEFORE it is wired into JS:
+    //  - A TrickleDown handler on the bridge root that calls StopImmediatePropagation()
+    //    prevents descendant elements (e.g. a nested ScrollView) from acting. This is the
+    //    mechanism the planned `preventDefault -> StopImmediatePropagation` will rely on.
+    //  - The bridge currently does NOT dispatch WheelEvent to JS (wheel is unbridged).
+
+    [UnityTest]
+    public IEnumerator Suppression_RootTrickleDownStop_PreventsDescendantPointerDown() {
+        var root = _uiDocument.rootVisualElement;
+
+        var child = new VisualElement { name = "SuppressChild" };
+        child.style.width = 100;
+        child.style.height = 100;
+        root.Add(child);
+        yield return null; // layout
+
+        bool childGotDown = false;
+        child.RegisterCallback<PointerDownEvent>(_ => childGotDown = true);
+
+        // Baseline: with nothing intercepting, the descendant receives PointerDown.
+        using (var evt = PointerDownEvent.GetPooled()) {
+            evt.target = child;
+            root.SendEvent(evt);
+        }
+        Assert.IsTrue(childGotDown,
+            "Baseline: descendant should receive PointerDown when nothing intercepts it.");
+
+        // Fix mechanism: a TrickleDown handler on root that stops immediate propagation
+        // must prevent the descendant from receiving the event at all.
+        childGotDown = false;
+        EventCallback<PointerDownEvent> stopper = e => e.StopImmediatePropagation();
+        root.RegisterCallback(stopper, TrickleDown.TrickleDown);
+        using (var evt = PointerDownEvent.GetPooled()) {
+            evt.target = child;
+            root.SendEvent(evt);
+        }
+        root.UnregisterCallback(stopper, TrickleDown.TrickleDown);
+
+        Assert.IsFalse(childGotDown,
+            "Fix: StopImmediatePropagation() in a root TrickleDown handler must prevent the " +
+            "descendant from receiving PointerDown. This is the path that lets a JS gesture " +
+            "suppress a nested ScrollView's native pan.");
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator Suppression_RootTrickleDownStop_StopsScrollViewWheelScroll() {
+        var root = _uiDocument.rootVisualElement;
+
+        var sv = new ScrollView(ScrollViewMode.Vertical);
+        sv.style.width = 200;
+        sv.style.height = 200;
+        var content = new VisualElement { name = "TallContent" };
+        content.style.height = 2000; // taller than the viewport, so it can scroll
+        sv.Add(content);
+        root.Add(sv);
+        yield return null;
+        yield return null; // a couple frames for layout
+
+        // Baseline: a positive wheel delta scrolls the ScrollView down.
+        sv.scrollOffset = Vector2.zero;
+        SendWheel(root, content, 50f);
+        yield return null;
+        float scrolled = sv.scrollOffset.y;
+        Assert.Greater(scrolled, 0f,
+            $"Baseline: ScrollView should scroll on a wheel delta. (scrollOffset.y = {scrolled})");
+
+        // Fix mechanism: root TrickleDown StopImmediatePropagation must keep scrollOffset put.
+        sv.scrollOffset = Vector2.zero;
+        EventCallback<WheelEvent> stopper = e => e.StopImmediatePropagation();
+        root.RegisterCallback(stopper, TrickleDown.TrickleDown);
+        SendWheel(root, content, 50f);
+        yield return null;
+        float suppressed = sv.scrollOffset.y;
+        root.UnregisterCallback(stopper, TrickleDown.TrickleDown);
+
+        Assert.AreEqual(0f, suppressed, 0.0001f,
+            "Fix: with StopImmediatePropagation() in a root TrickleDown WheelEvent handler, the " +
+            $"ScrollView must not scroll. (scrollOffset.y = {suppressed})");
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator Wheel_DispatchedToJsHandlerWithDelta() {
+        var root = _uiDocument.rootVisualElement;
+        int rootHandle = QuickJSNative.RegisterObject(root);
+
+        // Create a JS element that fills the panel and register onWheel on it (mirrors the
+        // pointer-capture test's JS-created-element pattern, which has correct handle
+        // bookkeeping). A WheelEvent at a point inside it picks it as the target, driving
+        // the real OnWheel -> FindElementHandle -> __dispatchEvent path end to end.
+        _bridge.Eval($@"
+            var root = __csHelpers.wrapObject('UnityEngine.UIElements.VisualElement', {rootHandle});
+            var el = new CS.UnityEngine.UIElements.VisualElement();
+            el.style.flexGrow = 1;
+            el.style.width = new CS.UnityEngine.UIElements.Length(100, CS.UnityEngine.UIElements.LengthUnit.Percent);
+            el.style.height = new CS.UnityEngine.UIElements.Length(100, CS.UnityEngine.UIElements.LengthUnit.Percent);
+            root.Add(el);
+            globalThis.__wheelEl = el;
+            globalThis.__wheelCount = 0;
+            globalThis.__wheelDeltaY = 0;
+            __eventAPI.addEventListener(el, 'wheel', (e) => {{
+                globalThis.__wheelCount++;
+                globalThis.__wheelDeltaY = e.deltaY;
+            }});
+        ");
+        yield return null;
+        yield return null; // layout so the element fills the panel and is pickable
+
+        int elHandle = int.Parse(_bridge.Eval("globalThis.__wheelEl.__csHandle"));
+        var elCs = QuickJSNative.GetObjectByHandle(elHandle) as VisualElement;
+        Assert.IsNotNull(elCs, "Should resolve the JS-created element back to C#.");
+
+        var systemEvent = new Event { type = EventType.ScrollWheel, delta = new Vector2(0f, 10f), mousePosition = new Vector2(10f, 10f) };
+        using (var evt = WheelEvent.GetPooled(systemEvent)) {
+            evt.target = elCs;
+            root.SendEvent(evt);
+        }
+        yield return null;
+
+        // Phase 1: WheelEvent is now bridged, so the JS onWheel handler fires with delta.
+        Assert.AreEqual("1", _bridge.Eval("globalThis.__wheelCount"),
+            $"Real WheelEvent should reach JS via the bridge (elHandle={elHandle}).");
+        Assert.AreEqual("true", _bridge.Eval("globalThis.__wheelDeltaY > 0"),
+            "The wheel deltaY should be forwarded to JS (positive for a downward scroll).");
+    }
+
+    // Helper: dispatch a synthetic vertical wheel scroll targeting `target`.
+    static void SendWheel(VisualElement root, VisualElement target, float deltaY) {
+        var systemEvent = new Event { type = EventType.ScrollWheel, delta = new Vector2(0f, deltaY) };
+        using (var evt = WheelEvent.GetPooled(systemEvent)) {
+            evt.target = target;
+            root.SendEvent(evt);
+        }
+    }
+
     /// <summary>
     /// Helper: set pointerId on a PointerEventBase via reflection.
     /// PointerEventBase.pointerId has a protected setter, so we use reflection for tests.

--- a/Tests/QuickJSUIBridgePlaymodeTests.cs
+++ b/Tests/QuickJSUIBridgePlaymodeTests.cs
@@ -543,6 +543,73 @@ public class QuickJSUIBridgePlaymodeTests {
     }
 
     [UnityTest]
+    public IEnumerator Suppression_FastPath_PreventDefaultInOnPointerDown_Suppresses() {
+        // Validates the PRODUCTION pointer path. JSRunner caches the fast dispatch callback,
+        // so pointer events go through DispatchEventFast -> InvokeCallbackReturnInt (not the
+        // string path the other tests use). A JS onPointerDown calling preventDefault() must
+        // suppress the native event (a descendant's PointerDown callback does not fire);
+        // without it, the descendant fires (backward-compat).
+        var root = _uiDocument.rootVisualElement;
+        int rootHandle = QuickJSNative.RegisterObject(root);
+
+        // Enable the fast path (mirrors JSRunner) and confirm it actually engaged.
+        _bridge.CacheEventDispatchCallback();
+        var dispatchHandleField = typeof(QuickJSUIBridge).GetField(
+            "_eventDispatchHandle", BindingFlags.NonPublic | BindingFlags.Instance);
+        int dispatchHandle = (int)dispatchHandleField.GetValue(_bridge);
+        Assert.GreaterOrEqual(dispatchHandle, 0,
+            "Fast dispatch path should be enabled so this test exercises DispatchEventFast / InvokeCallbackReturnInt.");
+
+        _bridge.Eval($@"
+            var root = __csHelpers.wrapObject('UnityEngine.UIElements.VisualElement', {rootHandle});
+            var child = new CS.UnityEngine.UIElements.VisualElement();
+            child.style.flexGrow = 1;
+            root.Add(child);
+            globalThis.__child = child;
+            globalThis.__pdFired = 0;
+            globalThis.__doPreventDefault = false;
+            __eventAPI.addEventListener(child, 'pointerdown', (e) => {{
+                globalThis.__pdFired++;
+                if (globalThis.__doPreventDefault) e.preventDefault();
+            }});
+        ");
+        yield return null;
+
+        int childHandle = int.Parse(_bridge.Eval("globalThis.__child.__csHandle"));
+        var childCs = QuickJSNative.GetObjectByHandle(childHandle) as VisualElement;
+        Assert.IsNotNull(childCs, "Child should resolve back to C#.");
+
+        bool childNativeGotDown = false;
+        childCs.RegisterCallback<PointerDownEvent>(_ => childNativeGotDown = true);
+
+        // Backward-compat: without preventDefault the native PointerDown reaches the child.
+        _bridge.Eval("globalThis.__pdFired = 0; globalThis.__doPreventDefault = false;");
+        childNativeGotDown = false;
+        using (var evt = PointerDownEvent.GetPooled()) {
+            evt.target = childCs;
+            root.SendEvent(evt);
+        }
+        yield return null;
+        Assert.AreEqual("1", _bridge.Eval("globalThis.__pdFired"),
+            "JS onPointerDown should fire via the fast path.");
+        Assert.IsTrue(childNativeGotDown,
+            "Without preventDefault, the child's native PointerDown callback should fire.");
+
+        // Suppression: with preventDefault the native PointerDown is suppressed.
+        _bridge.Eval("globalThis.__pdFired = 0; globalThis.__doPreventDefault = true;");
+        childNativeGotDown = false;
+        using (var evt = PointerDownEvent.GetPooled()) {
+            evt.target = childCs;
+            root.SendEvent(evt);
+        }
+        yield return null;
+        Assert.AreEqual("1", _bridge.Eval("globalThis.__pdFired"),
+            "JS onPointerDown should still fire via the fast path.");
+        Assert.IsFalse(childNativeGotDown,
+            "preventDefault() in onPointerDown must suppress the child's native PointerDown (fast path).");
+    }
+
+    [UnityTest]
     public IEnumerator Suppression_PreventDefaultInOnWheel_StopsScrollViewScroll() {
         // End-to-end Phase 2: a JS onWheel handler calling preventDefault() must stop the
         // enclosing ScrollView from scrolling (native suppression). Without preventDefault

--- a/Tests/QuickJSUIBridgePlaymodeTests.cs
+++ b/Tests/QuickJSUIBridgePlaymodeTests.cs
@@ -610,6 +610,77 @@ public class QuickJSUIBridgePlaymodeTests {
     }
 
     [UnityTest]
+    public IEnumerator Suppression_PerElement_PreventDefaultDuringCapture_Suppresses() {
+        // Phase 3a: once a pointer is captured, Unity 6 delivers pointer events directly to the
+        // capturing element, bypassing the _root TrickleDown handler — only the per-element
+        // handler (OnPerElementPointerMove) fires (see PerElementEventSupport). A JS
+        // onPointerMove calling preventDefault() must still suppress the native event mid-drag
+        // (e.g. a ScrollView pan); without it the native callback fires (backward-compat).
+        // Guards against the per-element handlers discarding the dispatch flags.
+        var root = _uiDocument.rootVisualElement;
+        int rootHandle = QuickJSNative.RegisterObject(root);
+
+        // String dispatch path (no CacheEventDispatchCallback) — the path per-element handlers use.
+        _bridge.Eval($@"
+            var root = __csHelpers.wrapObject('UnityEngine.UIElements.VisualElement', {rootHandle});
+            useExtensions(CS.UnityEngine.UIElements.PointerCaptureHelper);
+            var child = new CS.UnityEngine.UIElements.VisualElement();
+            child.style.width = 200; child.style.height = 200;
+            root.Add(child);
+            globalThis.__child = child;
+            globalThis.__pmFired = 0;
+            globalThis.__doPreventDefault = false;
+            __eventAPI.addEventListener(child, 'pointermove', (e) => {{
+                globalThis.__pmFired++;
+                if (globalThis.__doPreventDefault) e.preventDefault();
+            }});
+        ");
+        yield return null;
+
+        int childHandle = int.Parse(_bridge.Eval("globalThis.__child.__csHandle"));
+        var childCs = QuickJSNative.GetObjectByHandle(childHandle) as VisualElement;
+        Assert.IsNotNull(childCs, "Child should resolve back to C#.");
+
+        // Native PointerMove probe on the same element, registered AFTER the per-element handler
+        // (added via addEventListener above) so a StopImmediatePropagation from it suppresses this.
+        bool nativeGotMove = false;
+        childCs.RegisterCallback<PointerMoveEvent>(_ => nativeGotMove = true);
+
+        // Capture so events reach only the per-element handler, not _root TrickleDown.
+        childCs.CapturePointer(PointerId.mousePointerId);
+        Assert.IsTrue(childCs.HasPointerCapture(PointerId.mousePointerId),
+            "Child should have pointer capture.");
+
+        // Backward-compat: without preventDefault, the native PointerMove probe fires.
+        _bridge.Eval("globalThis.__pmFired = 0; globalThis.__doPreventDefault = false;");
+        nativeGotMove = false;
+        using (var evt = PointerMoveEvent.GetPooled()) {
+            SetPointerEventPointerId(evt, PointerId.mousePointerId);
+            root.SendEvent(evt);
+        }
+        yield return null;
+        Assert.AreEqual("1", _bridge.Eval("globalThis.__pmFired"),
+            "JS onPointerMove should fire via the per-element handler during capture.");
+        Assert.IsTrue(nativeGotMove,
+            "Without preventDefault, the native PointerMove probe should fire during capture.");
+
+        // Suppression: with preventDefault, the per-element handler must suppress the native probe.
+        _bridge.Eval("globalThis.__pmFired = 0; globalThis.__doPreventDefault = true;");
+        nativeGotMove = false;
+        using (var evt = PointerMoveEvent.GetPooled()) {
+            SetPointerEventPointerId(evt, PointerId.mousePointerId);
+            root.SendEvent(evt);
+        }
+        yield return null;
+        Assert.AreEqual("1", _bridge.Eval("globalThis.__pmFired"),
+            "JS onPointerMove should still fire via the per-element handler during capture.");
+        Assert.IsFalse(nativeGotMove,
+            "preventDefault() in onPointerMove must suppress the native event during pointer capture (per-element path).");
+
+        childCs.ReleasePointer(PointerId.mousePointerId);
+    }
+
+    [UnityTest]
     public IEnumerator Suppression_PreventDefaultInOnWheel_StopsScrollViewScroll() {
         // End-to-end Phase 2: a JS onWheel handler calling preventDefault() must stop the
         // enclosing ScrollView from scrolling (native suppression). Without preventDefault

--- a/Tests/QuickJSUIBridgePlaymodeTests.cs
+++ b/Tests/QuickJSUIBridgePlaymodeTests.cs
@@ -542,6 +542,55 @@ public class QuickJSUIBridgePlaymodeTests {
             "The wheel deltaY should be forwarded to JS (positive for a downward scroll).");
     }
 
+    [UnityTest]
+    public IEnumerator Suppression_PreventDefaultInOnWheel_StopsScrollViewScroll() {
+        // End-to-end Phase 2: a JS onWheel handler calling preventDefault() must stop the
+        // enclosing ScrollView from scrolling (native suppression). Without preventDefault
+        // the ScrollView still scrolls (backward-compatible).
+        var root = _uiDocument.rootVisualElement;
+        int rootHandle = QuickJSNative.RegisterObject(root);
+
+        _bridge.Eval($@"
+            var root = __csHelpers.wrapObject('UnityEngine.UIElements.VisualElement', {rootHandle});
+            var sv = new CS.UnityEngine.UIElements.ScrollView();
+            sv.style.width = 200; sv.style.height = 200;
+            root.Add(sv);
+            var content = new CS.UnityEngine.UIElements.VisualElement();
+            content.style.height = 2000;
+            sv.Add(content);
+            globalThis.__sv = sv;
+            globalThis.__content = content;
+            globalThis.__doPreventDefault = false;
+            __eventAPI.addEventListener(content, 'wheel', (e) => {{
+                if (globalThis.__doPreventDefault) e.preventDefault();
+            }});
+        ");
+        yield return null;
+        yield return null;
+
+        int contentHandle = int.Parse(_bridge.Eval("globalThis.__content.__csHandle"));
+        var contentCs = QuickJSNative.GetObjectByHandle(contentHandle) as VisualElement;
+        int svHandle = int.Parse(_bridge.Eval("globalThis.__sv.__csHandle"));
+        var sv = QuickJSNative.GetObjectByHandle(svHandle) as ScrollView;
+        Assert.IsNotNull(sv, "ScrollView should resolve back to C#.");
+
+        // Backward-compat: without preventDefault, the wheel scrolls the ScrollView.
+        sv.scrollOffset = Vector2.zero;
+        _bridge.Eval("globalThis.__doPreventDefault = false;");
+        SendWheel(root, contentCs, 50f);
+        yield return null;
+        Assert.Greater(sv.scrollOffset.y, 0f,
+            $"Without preventDefault the ScrollView should scroll. (scrollOffset.y={sv.scrollOffset.y})");
+
+        // Suppression: with preventDefault, the wheel must not scroll the ScrollView.
+        sv.scrollOffset = Vector2.zero;
+        _bridge.Eval("globalThis.__doPreventDefault = true;");
+        SendWheel(root, contentCs, 50f);
+        yield return null;
+        Assert.AreEqual(0f, sv.scrollOffset.y, 0.0001f,
+            $"preventDefault() in onWheel must stop the ScrollView from scrolling. (scrollOffset.y={sv.scrollOffset.y})");
+    }
+
     // Helper: dispatch a synthetic vertical wheel scroll targeting `target`.
     static void SendWheel(VisualElement root, VisualElement target, float deltaY) {
         var systemEvent = new Event { type = EventType.ScrollWheel, delta = new Vector2(0f, deltaY) };


### PR DESCRIPTION
## Summary

Two gaps in the UI Toolkit event bridge, surfaced by a user debugging session and verified with multiple multi-agent reviews:

1. **Mouse wheel was not bridged** (Phase 1).
2. **JS could not suppress native UI Toolkit behavior** (Phase 2): `preventDefault()` now maps to native `StopImmediatePropagation()`, so a JS gesture can stop a nested control (e.g. a ScrollView). `stopPropagation()` stays JS-bubble-only (backward-compatible).

Phase 3 extends suppression to captured pointers (mid-drag) and to WebGL. Verified against Unity 6000.3.0b10. See comments for the Phase 1 (Mono `string.Format`), Phase 2, and review-pass writeups.

## Status

- [x] Live Play-mode baseline confirmation
- [x] Phase 1: Wheel bridging (flat `{deltaX,deltaY}`, string path) - `20b95dc`
- [x] Phase 2: Native suppression (`preventDefault` -> `StopImmediatePropagation`, dispatch returns flags) - `1f0356e`
- [x] Fast-path suppression test (production pointer path: `DispatchEventFast` -> `InvokeCallbackReturnInt`) - `4d0fe04`
- [x] Docs deployed (events.mdx, scrollview.mdx, CLAUDE.md); onejs-react `WheelEventData` flat (0.1.24)
- [x] Phase 3a: per-element / captured-pointer suppression + PlayMode test - `a46d1ca`
- [x] Phase 3b: WebGL flag return (`qjs_dispatch_event` void -> int) - `d342142`
- [x] Follow-ups: stale `Suppression_RootTrickleDownStop_*` test cleanup + `InvokeAndGetInt` defensive string-free - `1d87c49`

All PlayMode tests pass (57/57 across UIBridge + FastPath + ZeroAlloc); no perf/alloc regression on the per-frame pointermove path. The Phase 3b WebGL path compiles behind `#if UNITY_WEBGL && !UNITY_EDITOR` and needs a WebGL build to verify at runtime.

## Phase 3a notes

`ApplyNativeSuppression(e, flags)` is now wired into `OnPerElementPointer{Down,Up,Move,Cancel,Stationary}` in `QuickJSUIBridge.cs` (they previously discarded the dispatch flags). This closes the one user-visible gap: `preventDefault()` lapsed once a pointer was captured mid-drag over a ScrollView, because Unity 6 delivers captured pointer events directly to the element, bypassing the root TrickleDown handler, so only the per-element handler fires.

`Suppression_PerElement_PreventDefaultDuringCapture_Suppresses` guards it: with the wiring reverted the test fails at the suppression assertion, which also confirms the root handler does not fire during capture (the per-element path is what does the work).
