### PR TITLE
Fix native fetch when C# Task completes synchronously

### DIFF
--- a/Resources/OneJS/QuickJSBootstrap.js.txt
+++ b/Resources/OneJS/QuickJSBootstrap.js.txt
@@ -2241,7 +2241,7 @@ if (__nativeFetch) {
         var headersJson = headers ? JSON.stringify(headers) : null;
 
         // Call C# FetchAsync and wrap result in Response object
-        return CS.OneJS.Network.FetchAsync(url, method, body, headersJson)
+        return Promise.resolve(CS.OneJS.Network.FetchAsync(url, method, body, headersJson))
             .then(function(result) {
                 return new Response(result);
             });


### PR DESCRIPTION
## Summary

This PR fixes `fetch()` on native Unity platforms when `CS.OneJS.Network.FetchAsync(...)` completes synchronously.

Previously, the native fetch bootstrap always assumed that the C# call returned a JavaScript Promise:

```js
return CS.OneJS.Network.FetchAsync(url, method, body, headersJson)
    .then(function(result) {
        return new Response(result);
    });
```

However, the OneJS C# → JavaScript bridge has two valid return paths:

- A pending `Task<T>` is exposed as a JavaScript Promise.
- An already-completed `Task<T>` is unwrapped and returned as its direct value.

Small Android `StreamingAssets` requests using `jar:file://...apk!/assets/...` may complete synchronously. In that case, `FetchAsync` returns the response JSON string directly, and the bootstrap attempts to call `.then()` on that string:

```text
TypeError: not a function
```

This prevents the `Response` object from being created and breaks consumers such as asynchronous SVG loading.

## Fix

Normalize the result through `Promise.resolve(...)` before continuing the response conversion:

```js
return Promise.resolve(
    CS.OneJS.Network.FetchAsync(url, method, body, headersJson)
).then(function(result) {
    return new Response(result);
});
```

This supports both pending tasks and synchronously completed tasks without changing the existing fetch API.

## Impact

The fix applies to native OneJS `fetch()` calls in general, including Android assets loaded from inside the APK. It is not specific to SVG files, although asynchronous SVG loading is one reproducible case.

## Verification

Verified with:

- Unity `6000.6.0f1`
- Android / IL2CPP
- Assets stored in APK `StreamingAssets`
- `onejs-react` `0.1.41`
- `onejs-unity` `0.2.16`

Before the change:

```text
Image src failed to load: ...svg
TypeError: not a function
```

After the change, the same SVG assets load and render correctly on the Android headset.